### PR TITLE
Fix color theming in KaTeX inline text

### DIFF
--- a/_site/assets/css/main.css
+++ b/_site/assets/css/main.css
@@ -833,4 +833,8 @@ d-appendix a:hover, d-appendix a.footnote-backlink:hover {
   }
 }
 
+.katex * {
+  color: var(--global-text-color) !important;
+}
+
 /*# sourceMappingURL=main.css.map */


### PR DESCRIPTION
# Summary

should fix dark mode for inline LaTeX equations in the blog.

# Testing

lol i didn't test it because i didn't want to get all the dependencies and stuff. hopefully this works